### PR TITLE
Allow IconView to be added to ScrolledWindow using add()

### DIFF
--- a/src/bindings/org/gnome/gtk/ScrolledWindow.java
+++ b/src/bindings/org/gnome/gtk/ScrolledWindow.java
@@ -125,7 +125,8 @@ public class ScrolledWindow extends Bin
     public void addWithViewport(Widget child) {
         final Viewport port;
 
-        if ((child instanceof TextView) || (child instanceof TreeView) || (child instanceof IconView) || (child instanceof Layout)) {
+        if ((child instanceof TextView) || (child instanceof TreeView) || (child instanceof Layout)) {
+            // in future, IconView; for now we allow IconView in both add() and addWithViewport()
             // any others?
             throw new IllegalArgumentException(
                     "You must not addWithViewport() a Widget that already has scrolling support built in. Use Container's add() instead.");


### PR DESCRIPTION
IconView has scrolling support, so it shouldn't have to be added using
addWithViewport(). When you use addWithViewport(), the IconView does
not correctly re-flow icons as the ScrolledWindow is resized; it
re-flows when the window is widened, but adds a horizontal scrollbar
when the window is narrowed.

A demo program illustrates this issue: http://pastebin.com/HajMj2uh
