### PR TITLE
Doc accessibility bug

### DIFF
--- a/build/faster
+++ b/build/faster
@@ -679,6 +679,7 @@ def compileDocumentation():
 
 
 def takeSnapshots():
+	os.environ['NO_AT_BRIDGE'] = '1'
 	runJavaClass("Harness", "tmp/gtk-4.1.jar:tmp/tests/")
 
 


### PR DESCRIPTION
Disable AT Bridge when taking snapshots for documentation.
This is required to be able to build the documentation in chroot for packages build (such as the one that Debian/Ubuntu use). Moreover I see no point of leaving the AT Bridge enabled for the documentation generation.
