### PR TITLE
Corrects VCS used in the README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -50,7 +50,7 @@ configuration command.
 ### Or checkout the source ###
 
 If you want a newer version of the code than the tarball you might have, you
-can always check it out over the net. We use Bazaar (`bzr`), an advanced
+can always check it out over the net. We use Git, an advanced
 third-generation Distributed Version [or Revision] Control System, to manage
 our source code. 
 


### PR DESCRIPTION
The README said you used GNU bzr - right above instructions on cloning with Git. 
