### PR TITLE
Fix #24: add bindings for CssProvider sufficient to do basic css

### DIFF
--- a/configure
+++ b/configure
@@ -892,6 +892,11 @@ if ($os eq "gentoo") {
 			"Enchant",
 			"libenchant-dev");
 
+	check_system_library(@gnomedev_libs,
+			"libnotify",
+			"LibNotify",
+			"libnotify-dev");
+
 #	check_system_library(@gnomedev_libs,
 #			"gtkspell-3.0",
 #			"GtkSpell",

--- a/src/bindings/org/gnome/gtk/CssProvider.java
+++ b/src/bindings/org/gnome/gtk/CssProvider.java
@@ -1,0 +1,121 @@
+/*
+ * java-gnome, a UI library for writing GTK and GNOME programs from Java!
+ *
+ * Copyright © 2020 java-gnome contributors
+ *
+ * The code in this file, and the program it is a part of, is made available
+ * to you by its authors as open source software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License version
+ * 2 ("GPL") as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL for more details.
+ *
+ * You should have received a copy of the GPL along with this program. If not,
+ * see http://www.gnu.org/licenses/. The authors of this program may be
+ * contacted through http://java-gnome.sourceforge.net/.
+ *
+ * Linking this library statically or dynamically with other modules is making
+ * a combined work based on this library. Thus, the terms and conditions of
+ * the GPL cover the whole combination. As a special exception (the
+ * "Classpath Exception"), the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent modules,
+ * and to copy and distribute the resulting executable under terms of your
+ * choice, provided that you also meet, for each linked independent module,
+ * the terms and conditions of the license of that module. An independent
+ * module is a module which is not derived from or based on this library. If
+ * you modify this library, you may extend the Classpath Exception to your
+ * version of the library, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
+ */
+package org.gnome.gtk;
+
+import org.gnome.gdk.Screen;
+import org.gnome.glib.GlibException;
+import org.gnome.glib.Object;
+
+/**
+ * CSS-like styling for widgets
+ * <br/><br/>
+ * CssProvider is an object implementing the {@link StyleProvider} interface. 
+ * It is able to parse CSS-like input in order to style widgets.
+ * <br/><br/>
+ * An application can make GTK+ parse a specific CSS style sheet by calling 
+ * {@link #loadFromPath(String)} or {@link #loadFromResource(String)} and 
+ * adding the provider with {@link StyleContext#addProvider(StyleProvider, int)} 
+ * or {@link StyleContext#addProviderForScreen(Screen, StyleProvider, int)}
+ * 
+ * @author Patrick Plenefisch
+ * @since 4.1.4
+ */
+public class CssProvider extends Object implements StyleProvider
+{
+    protected CssProvider(long pointer) {
+        super(pointer);
+    }
+
+    /**
+     * Creates a new CssProvider
+     * 
+     * @since 4.1.4
+     */
+    public CssProvider() {
+        super(GtkCssProvider.createCssProvider());
+    }
+
+    /**
+     * Loads a theme from the usual theme paths.
+     * 
+     * @since 4.1.4
+     */
+    public static CssProvider getNamed(String name, String variant) {
+        return GtkCssProvider.getNamed(name, variant);
+    }
+    /**
+     * Loads the data contained in the resource at resource_path into the 
+     * CssProvider, clearing any previously loaded information.
+     * 
+     * @since 4.1.4
+     */
+    public void loadFromResource(String resource_path) {
+        GtkCssProvider.loadFromResource(this, resource_path);
+    }
+    
+    /**
+     * Loads data into css_provider , and by doing so clears any previously loaded information.
+     * 
+     * @since 4.1.4
+     */
+    public boolean loadFromData(String data) {
+        try {
+	    return GtkCssProvider.loadFromData(this, data, data.length());
+        } catch (GlibException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+    
+    /**
+     * Loads the data contained in path into css_provider,
+     * making it clear any previously loaded information.
+     * 
+     * @since 4.1.4
+     */
+    public boolean loadFromPath(String path) {
+    	try {
+	    return GtkCssProvider.loadFromPath(this, path);
+        } catch (GlibException e) {
+            throw new RuntimeException(e.getMessage());
+        }
+    }
+
+    /**
+     * Converts the provider into a string representation in CSS format.
+     * 
+     * @since 4.1.4
+     */
+    public String toString() {
+        return GtkCssProvider.toString(this);
+    }
+}

--- a/src/bindings/org/gnome/gtk/Settings.java
+++ b/src/bindings/org/gnome/gtk/Settings.java
@@ -2,6 +2,7 @@
  * java-gnome, a UI library for writing GTK and GNOME programs from Java!
  *
  * Copyright © 2007-2010 Operational Dynamics Consulting, Pty Ltd
+ * Copyright © 2020 java-gnome contributors
  *
  * The code in this file, and the program it is a part of, is made available
  * to you by its authors as open source software: you can redistribute it
@@ -53,7 +54,7 @@ import org.gnome.glib.Object;
  * reason is completion space; there are property getters on this class, and
  * getDefault() just doesn't make sense alongside them.
  */
-public class Settings extends Object
+public class Settings extends Object implements StyleProvider
 {
     protected Settings(long pointer) {
         super(pointer);

--- a/src/bindings/org/gnome/gtk/StyleContext.java
+++ b/src/bindings/org/gnome/gtk/StyleContext.java
@@ -2,6 +2,7 @@
  * java-gnome, a UI library for writing GTK and GNOME programs from Java!
  *
  * Copyright © 2007-2011 Operational Dynamics Consulting, Pty Ltd and Others
+ * Copyright © 2020 java-gnome contributors
  *
  * The code in this file, and the program it is a part of, is made available
  * to you by its authors as open source software: you can redistribute it
@@ -154,6 +155,46 @@ public class StyleContext extends Object
      */
     public void addRegion(StyleRegion region, RegionFlags flags) {
         GtkStyleContext.addRegion(this, region.getStyleName(), flags);
+    }
+
+    /**
+     * Adds a global style provider to <code>screen</code>, which will be used in style
+     * construction for all StyleContexts under screen.
+     * <br/><br/>
+     * GTK+ uses this to make styling information from {@link Settings} available.
+     * <br/><br/>
+     * Note: If both priorities are the same, A {@link StyleProvider} added through 
+     * {@link #addProvider(StyleProvider, int)} takes precedence over another added 
+     * through this function.
+     * 
+     * @param priority the priority of the style provider. The lower it is, the earlier it 
+     * will be used in the style construction. Typically this will be in the range between 
+     * {@link StyleProvider#PRIORITY_FALLBACK} and {@link StyleProvider#PRIORITY_USER}
+     * 
+     * @since 4.1.4
+     */
+    public static void addProviderForScreen(Screen screen, StyleProvider provider, int priority) {
+        GtkStyleContext.addProviderForScreen(screen, provider, priority);
+    }
+    
+    /**
+     * Adds a style provider to StyleContext, to be used in style construction.
+     * Note that a style provider added by this function only affects the style of 
+     * the widget to which context belongs. If you want to affect the style of 
+     * all widgets, use {@link #addProviderForScreen(Screen, StyleProvider, int)}
+     * <br/><br/>
+     * Note: If both priorities are the same, a {@link StyleProvider} added through
+     * this function takes precedence over another added through 
+     * {@link #addProviderForScreen(Screen, StyleProvider, int)}
+     * 
+     * @param priority the priority of the style provider. The lower it is, the earlier it 
+     * will be used in the style construction. Typically this will be in the range between 
+     * {@link StyleProvider#PRIORITY_FALLBACK} and {@link StyleProvider#PRIORITY_USER}
+     * 
+     * @since 4.1.4
+     */
+    public void addProvider(StyleProvider provider, int priority) {
+        GtkStyleContext.addProvider(this, provider, priority);
     }
 
     /**

--- a/src/bindings/org/gnome/gtk/StyleProvider.java
+++ b/src/bindings/org/gnome/gtk/StyleProvider.java
@@ -1,0 +1,79 @@
+/*
+ * java-gnome, a UI library for writing GTK and GNOME programs from Java!
+ *
+ * Copyright © 2020 java-gnome contributors
+ *
+ * The code in this file, and the program it is a part of, is made available
+ * to you by its authors as open source software: you can redistribute it
+ * and/or modify it under the terms of the GNU General Public License version
+ * 2 ("GPL") as published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE. See the GPL for more details.
+ *
+ * You should have received a copy of the GPL along with this program. If not,
+ * see http://www.gnu.org/licenses/. The authors of this program may be
+ * contacted through http://java-gnome.sourceforge.net/.
+ *
+ * Linking this library statically or dynamically with other modules is making
+ * a combined work based on this library. Thus, the terms and conditions of
+ * the GPL cover the whole combination. As a special exception (the
+ * "Classpath Exception"), the copyright holders of this library give you
+ * permission to link this library with independent modules to produce an
+ * executable, regardless of the license terms of these independent modules,
+ * and to copy and distribute the resulting executable under terms of your
+ * choice, provided that you also meet, for each linked independent module,
+ * the terms and conditions of the license of that module. An independent
+ * module is a module which is not derived from or based on this library. If
+ * you modify this library, you may extend the Classpath Exception to your
+ * version of the library, but you are not obligated to do so. If you do not
+ * wish to do so, delete this exception statement from your version.
+ */
+package org.gnome.gtk;
+
+/**
+ * Interface to provide style information to {@link StyleContext}
+ * 
+ * @see StyleContext
+ * @see CssProvider
+ * 
+ * @author Patrick Plenefisch
+ * @since 4.1.4
+ */
+public interface StyleProvider
+{
+    /**
+     * The priority used for default style information that is used in the absence of themes.
+     * <br/><br/>
+     * Note that this is not very useful for providing default styling for custom style classes 
+     * - themes are likely to override styling provided at this priority with 
+     * catch-all <code>* {...}</code> rules.
+     */
+    public final static int PRIORITY_FALLBACK = 1;
+
+    /**
+     * The priority used for style information provided by themes.
+     */
+    public final static int  PRIORITY_THEME = 200;
+
+    /**
+     * The priority used for style information provided via {@link Settings}.
+     * <br/><br/>
+     * This priority is higher than {@link #PRIORITY_THEME} to let settings override themes.
+     */
+    public final static int  PRIORITY_SETTINGS = 400;
+
+    /**
+     * A priority that can be used when adding a StyleProvider for application-specific style information.
+     */
+    public final static int  PRIORITY_APPLICATION = 600;
+
+    /**
+     * The priority used for the style information from <code>XDG_CONFIG_HOME/gtk-3.0/gtk.css</code>.
+     * <br/><br/>
+     * You should not use priorities higher than this, to give the user the last word.
+     */
+    public final static int  PRIORITY_USER = 800;
+
+}

--- a/src/defs/GtkCssProvider.defs
+++ b/src/defs/GtkCssProvider.defs
@@ -1,0 +1,63 @@
+(define-object CssProvider
+  (in-module "Gtk")
+  (parent "GObject")
+  (implements "GtkStyleProvider")
+  (c-name "GtkCssProvider")
+  (gtype-id "GTK_TYPE_CSS_PROVIDER")
+)
+
+(define-function new
+  (is-constructor-of "GtkCssProvider")
+  (c-name "gtk_css_provider_new")
+  (caller-owns-return #t)
+  (return-type "GtkCssProvider*")
+)
+
+(define-function get_named
+  (of-object "GtkCssProvider")
+  (c-name "gtk_css_provider_get_named")
+  (caller-owns-return #f)
+  (return-type "GtkCssProvider*")
+  (parameters
+    '("const-gchar*" "name")
+    '("const-gchar*" "variant")
+  )
+)
+
+(define-method load_from_data
+  (of-object "GtkCssProvider")
+  (c-name "gtk_css_provider_load_from_data")
+  (return-type "gboolean")
+  (parameters
+    '("const-gchar*" "data")
+    '("gsize" "length")
+    '("GError**" "error")
+  )
+)
+
+(define-method load_from_resource
+  (of-object "GtkCssProvider")
+  (c-name "gtk_css_provider_load_from_resource")
+  (return-type "none")
+  (parameters
+    '("const-gchar*" "resource_path")
+  )
+)
+
+(define-method load_from_path
+  (of-object "GtkCssProvider")
+  (c-name "gtk_css_provider_load_from_path")
+  (return-type "gboolean")
+  (parameters
+    '("const-gchar*" "path")
+    '("GError**" "error")
+  )
+)
+
+(define-method to_string
+  (of-object "GtkCssProvider")
+  (c-name "gtk_css_provider_to_string")
+  (return-type "char*")
+)
+
+

--- a/src/defs/GtkSettings.defs
+++ b/src/defs/GtkSettings.defs
@@ -1,6 +1,7 @@
 (define-object Settings
   (in-module "Gtk")
   (parent "GObject")
+  (implements "GtkStyleProvider")
   (c-name "GtkSettings")
   (gtype-id "GTK_TYPE_SETTINGS")
 )

--- a/src/defs/GtkStyleContext.defs
+++ b/src/defs/GtkStyleContext.defs
@@ -27,6 +27,27 @@
   )
 )
 
+(define-method add_provider
+  (of-object "GtkStyleContext")
+  (c-name "gtk_style_context_add_provider")
+  (return-type "none")
+  (parameters
+    '("GtkStyleProvider*" "provider")
+    '("guint" "priority")
+  )
+)
+
+(define-function add_provider_for_screen
+  (of-object "GtkStyleContext")
+  (c-name "gtk_style_context_add_provider_for_screen")
+  (return-type "none")
+  (parameters
+    '("GdkScreen*" "screen")
+    '("GtkStyleProvider*" "provider")
+    '("guint" "priority")
+  )
+)
+
 (define-method get_state
   (of-object "GtkStyleContext")
   (c-name "gtk_style_context_get_state")

--- a/src/defs/GtkStyleProvider.defs
+++ b/src/defs/GtkStyleProvider.defs
@@ -1,0 +1,7 @@
+(define-interface StyleProvider
+  (in-module "Gtk")
+  (c-name "GtkStyleProvider")
+  (gtype-id "GTK_TYPE_STYLE_PROVIDER")
+)
+
+; get_style_property requires WidgetPath


### PR DESCRIPTION
I didn't add any interface methods, as two are deprecated and the 3rd required more work, but css can now be loaded by:
```java
provider = new org.gnome.gtk.CssProvider();
provider.loadFromPath("my.css");
org.gnome.gtk.StyleContext.addProviderForScreen(
    org.gnome.gdk.Screen.getDefault(), 
    provider,
    org.gnome.gtk.StyleProvider.PRIORITY_APPLICATION); // 600
```
I also added the libnotify-dev dependency for Ubuntu/Debian after I got similar errors as #18 
