### PR TITLE
Update debian & pkgconfig names for libenchant

### DIFF
--- a/build/faster
+++ b/build/faster
@@ -63,7 +63,7 @@ versionFile = "src/bindings/org/freedesktop/bindings/Version.java"
 hashFile = "tmp/.hashes"
 lockFile = "tmp/.build"
 
-GNOME_MODULES = "gthread-2.0 glib-2.0 gtk+-3.0 gtk+-unix-print-3.0 gtksourceview-3.0 libnotify enchant librsvg-2.0"
+GNOME_MODULES = "gthread-2.0 glib-2.0 gtk+-3.0 gtk+-unix-print-3.0 gtksourceview-3.0 libnotify enchant-2 librsvg-2.0"
 
 #
 # Armour against multiple simultaneous invocations.

--- a/configure
+++ b/configure
@@ -888,9 +888,9 @@ if ($os eq "gentoo") {
 			"libgtksourceview-3.0-dev");
 
 	check_system_library(@gnomedev_libs,
-			"enchant",
+			"enchant-2",
 			"Enchant",
-			"libenchant-dev");
+			"libenchant-2-dev");
 
 	check_system_library(@gnomedev_libs,
 			"libnotify",


### PR DESCRIPTION
This tweaks the package named for libenchant to match the current debian package names. The libraries build and using them in an existing project yields no problems. I wasn't able to get xvfb working to run the test suite though.